### PR TITLE
Set Elasticsearch default data instance type to t3.medium.elasticsearch

### DIFF
--- a/resources/tenant-onboarding-es.yaml
+++ b/resources/tenant-onboarding-es.yaml
@@ -64,7 +64,7 @@ Parameters:
   ElasticsearchDataInstanceType:
     Description: Instance type for data nodes.
     Type: String
-    Default: 'r5.2xlarge.elasticsearch'
+    Default: 't3.medium.elasticsearch'
   NumberOfMasterNodes:
     Description: How many dedicated master nodes you want to have. 3 is recommended.
     Type: Number
@@ -104,7 +104,7 @@ Resources:
         EBSEnabled: !Ref EBSEnabled
         Iops: 0
         VolumeSize: !Ref EBSVolumeSize
-        VolumeType: standard
+        VolumeType: gp2
       ElasticsearchClusterConfig:
         InstanceCount: !Ref NumberOfDataNodes
         InstanceType: !Ref ElasticsearchDataInstanceType

--- a/resources/tenant-onboarding.yaml
+++ b/resources/tenant-onboarding.yaml
@@ -169,8 +169,9 @@ Parameters:
   ElasticsearchDataInstanceType:
     Description: Instance type for data nodes.
     Type: String
-    Default: r5.2xlarge.elasticsearch
+    Default: t3.medium.elasticsearch
     AllowedValues:
+      - t3.medium.elasticsearch
       - r5.large.elasticsearch
       - r5.xlarge.elasticsearch
       - r5.2xlarge.elasticsearch


### PR DESCRIPTION
Using a less expensive instance type

references
- supported instance types - https://docs.aws.amazon.com/opensearch-service/latest/developerguide/supported-instance-types.html
- pricing - https://aws.amazon.com/opensearch-service/pricing/
